### PR TITLE
Deduction of amount already paid

### DIFF
--- a/ps_checkpayment.php
+++ b/ps_checkpayment.php
@@ -171,10 +171,11 @@ class Ps_Checkpayment extends PaymentModule
         }
 
         $state = $params['order']->getCurrentState();
+        $rest_to_paid = $params['order']->getOrdersTotalPaid() - $params['order']->getTotalPaid();
         if (in_array($state, array(Configuration::get('PS_OS_CHEQUE'), Configuration::get('PS_OS_OUTOFSTOCK'), Configuration::get('PS_OS_OUTOFSTOCK_UNPAID')))) {
             $this->smarty->assign(array(
                 'total_to_pay' => Tools::displayPrice(
-                    $params['order']->getOrdersTotalPaid(),
+                    $rest_to_paid,
                     new Currency($params['order']->id_currency),
                     false
                 ),


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Branch?       | develop
| Description?  | An order can have other payment on the same order process we can have a payment that is made before (eg payment by gift card or balance / have), so it is necessary to deduct the amount that has already been paid. This update have visual impact for the final customer. I regularly implement this update near my clients.<br>Maybe one day we will be able to make multiple payments, this update is a first step :-).
| Type?         | Feature
| Category?     | MO
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | no
| How to test?  |  Paid with check payment and check if amount is good.
