### PR TITLE
Fix non-existent image src in admin

### DIFF
--- a/views/templates/hook/infos.tpl
+++ b/views/templates/hook/infos.tpl
@@ -24,7 +24,7 @@
 *}
 
 <div class="alert alert-info">
-<img src="../modules/ps_checkpayment/ps_checkpayment.jpg" style="float:left; margin-right:15px;" width="86" height="49">
+<img src="../modules/ps_checkpayment/logo.png" style="float:left; margin-right:15px;" height="60">
 <p><strong>{l s="This module allows you to accept payments by check." d='Modules.Checkpayment.Admin'}</strong></p>
 <p>{l s="If the client chooses this payment method, the order status will change to 'Waiting for payment'." d='Modules.Checkpayment.Admin'}</p>
 <p>{l s="You will need to manually confirm the order as soon as you receive a check." d='Modules.Checkpayment.Admin'}</p>


### PR DESCRIPTION
Fix non-existent image src in admin by pointing to the mandatory logo.png. Also removed the width parameter (so it doesn't have to be changed with every image change) and modified the height to match the text :)