### PR TITLE
Fix : <br /> displayed in check address after order

### DIFF
--- a/views/templates/hook/payment_return.tpl
+++ b/views/templates/hook/payment_return.tpl
@@ -29,7 +29,7 @@
 		{l s='Your check must include:' d='Modules.Checkpayment.Shop'}
 		<br /><br />- {l s='Payment amount.' d='Modules.Checkpayment.Shop'} <span class="price"><strong>{$total_to_pay}</strong></span>
 		<br /><br />- {l s='Payable to the order of' d='Modules.Checkpayment.Shop'} <strong>{if $checkName}{$checkName}{else}___________{/if}</strong>
-		<br /><br />- {l s='Mail to' d='Modules.Checkpayment.Shop'} <strong>{if $checkAddress}{$checkAddress}{else}___________{/if}</strong>
+		<br /><br />- {l s='Mail to' d='Modules.Checkpayment.Shop'} <strong>{if $checkAddress}{$checkAddress nofilter}{else}___________{/if}</strong>
 		{if !isset($reference)}
 			<br /><br />- {l s='Do not forget to insert your order number #%d.' sprintf=[$id_order] d='Modules.Checkpayment.Shop'}
 		{else}


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 
Please take the time to edit the "Answers" rows below with the necessary information.
Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | Fix the <br /> displayed when the configuration field "CHEQUE_ADDRESS" contains break line
| Type?         | bug fix 
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/20075
| How to test?  |     1 -Any product and click Add to cart / 2- Go to cart and follow steps until payment  / 3- Select payment mode check 4- Confirm order and see the line about checkpayment


