### PR TITLE
 Check compatibility PHP 5.6 to PHP 8.1

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -58,7 +58,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                presta-versions: ['1.7.6.0', 'latest']
+                presta-versions: ['1.7.6', '1.7.7', '1.7.8', 'latest']
         steps:
             - name: Setup PHP
               uses: shivammathur/setup-php@v2

--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -3,7 +3,7 @@ on: [push, pull_request]
 jobs:
     # Check there is no syntax errors in the project
     php-linter:
-        name: PHP Syntax check 5.6|7.2|7.3
+        name: PHP Syntax check 5.6|7.2|7.3|7.4|8.0|8.1
         runs-on: ubuntu-latest
         steps:
             - name: Checkout
@@ -17,6 +17,15 @@ jobs:
 
             - name: PHP syntax checker 7.3
               uses: prestashop/github-action-php-lint/7.3@master
+
+            - name: PHP syntax checker 7.4
+              uses: prestashop/github-action-php-lint/7.4@master
+
+            - name: PHP syntax checker 8.0
+              uses: prestashop/github-action-php-lint/8.0@master
+
+            - name: PHP syntax checker 8.1
+              uses: prestashop/github-action-php-lint/8.1@master
 
     # Check the PHP code follow the coding standards
     php-cs-fixer:


### PR DESCRIPTION
<!-----------------------------------------------------------------------------
Thank you for contributing to the PrestaShop project! 

Please take the time to edit the "Answers" rows below with the necessary information.

Check out our contribution guidelines to find out how to complete it:
https://devdocs.prestashop.com/1.7/contribute/contribution-guidelines/#pull-requests
------------------------------------------------------------------------------>

| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  |  Check compatibility PHP 5.6 to PHP 8.1
| Type?         | improvement
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Relative to PrestaShop/Prestashop#25921
| How to test?  | N/A

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
