### PR TITLE
Clean legacy status check and template

### DIFF
--- a/ps_checkpayment.php
+++ b/ps_checkpayment.php
@@ -170,26 +170,20 @@ class Ps_Checkpayment extends PaymentModule
             return;
         }
 
-        $state = $params['order']->getCurrentState();
         $rest_to_paid = $params['order']->getOrdersTotalPaid() - $params['order']->getTotalPaid();
-        if (in_array($state, [Configuration::get('PS_OS_CHEQUE'), Configuration::get('PS_OS_OUTOFSTOCK'), Configuration::get('PS_OS_OUTOFSTOCK_UNPAID')])) {
-            $this->smarty->assign([
-                'total_to_pay' => $this->context->getCurrentLocale()->formatPrice(
-                    $rest_to_paid,
-                    (new Currency($params['order']->id_currency))->iso_code
-                ),
-                'shop_name' => $this->context->shop->name,
-                'checkName' => $this->checkName,
-                'checkAddress' => Tools::nl2br($this->address),
-                'status' => 'ok',
-                'id_order' => $params['order']->id,
-            ]);
-            if (isset($params['order']->reference) && !empty($params['order']->reference)) {
-                $this->smarty->assign('reference', $params['order']->reference);
-            }
-        } else {
-            $this->smarty->assign('status', 'failed');
-        }
+
+        $this->smarty->assign([
+            'total_to_pay' => $this->context->getCurrentLocale()->formatPrice(
+                $rest_to_paid,
+                (new Currency($params['order']->id_currency))->iso_code
+            ),
+            'shop_name' => $this->context->shop->name,
+            'checkName' => $this->checkName,
+            'checkAddress' => Tools::nl2br($this->address),
+            'status' => 'ok',
+            'id_order' => $params['order']->id,
+            'reference' => $params['order']->reference,
+        ]);
 
         return $this->fetch('module:ps_checkpayment/views/templates/hook/payment_return.tpl');
     }

--- a/views/templates/hook/payment_return.tpl
+++ b/views/templates/hook/payment_return.tpl
@@ -23,57 +23,33 @@
  * @license   https://opensource.org/licenses/AFL-3.0 Academic Free License 3.0 (AFL-3.0)
  *}
 
-{if $status == 'ok'}
-	<p>
-		{l s='Your order on %s is complete.' sprintf=[$shop_name] d='Modules.Checkpayment.Shop'}
-	</p>
+<p>{l s='Your order on %s is complete.' sprintf=[$shop_name] d='Modules.Checkpayment.Shop'}</p>
+<p>{l s='Your check must include:' d='Modules.Checkpayment.Shop'}</p>
 
-	<p>
-		{l s='Your check must include:' d='Modules.Checkpayment.Shop'}
-	</p>
+<ul>
+	<li>
+		{l s='Payment amount.' d='Modules.Checkpayment.Shop'}
+		<span class="price"><strong>{$total_to_pay}</strong></span>
+	</li>
 
-	<ul>
-		<li>
-			{l s='Payment amount.' d='Modules.Checkpayment.Shop'}
-			<span class="price"><strong>{$total_to_pay}</strong></span>
-		</li>
+	<li>
+		{l s='Payable to the order of' d='Modules.Checkpayment.Shop'}
+		<strong>{if $checkName}{$checkName}{else}___________{/if}</strong>
+	</li>
 
-		<li>
-			{l s='Payable to the order of' d='Modules.Checkpayment.Shop'}
-			<strong>{if $checkName}{$checkName}{else}___________{/if}</strong>
-		</li>
+	<li>
+		{l s='Mail to' d='Modules.Checkpayment.Shop'}
+		<strong>{if $checkAddress}{$checkAddress nofilter}{else}___________{/if}</strong>
+	</li>
 
-		<li>
-			{l s='Mail to' d='Modules.Checkpayment.Shop'}
-			<strong>{if $checkAddress}{$checkAddress nofilter}{else}___________{/if}</strong>
-		</li>
+	<li>
+		{l s='Do not forget to insert your order reference %s.' sprintf=[$reference] d='Modules.Checkpayment.Shop'}
+	</li>
+</ul>
 
-		{if !isset($reference)}
-			<li>
-				{l s='Do not forget to insert your order number #%d.' sprintf=[$id_order] d='Modules.Checkpayment.Shop'}
-			</li>
-		{else}
-			<li>
-				{l s='Do not forget to insert your order reference %s.' sprintf=[$reference] d='Modules.Checkpayment.Shop'}
-			</li>
-		{/if}
-	</ul>
+<p>{l s='An email has been sent to you with this information.' d='Modules.Checkpayment.Shop'}</p>
+<p><strong>{l s='Your order will be sent as soon as we receive your payment.' d='Modules.Checkpayment.Shop'}</strong></p>
 
-	<p>
-		{l s='An email has been sent to you with this information.' d='Modules.Checkpayment.Shop'}
-	</p>
-
-	<p>
-		<strong>{l s='Your order will be sent as soon as we receive your payment.' d='Modules.Checkpayment.Shop'}</strong>
-	</p>
-
-	<p>
-		{l s='For any questions or for further information, please contact our' d='Modules.Checkpayment.Shop'}
-		<a href="{$link->getPageLink('contact', true)|escape:'html'}">{l s='customer service department.' d='Modules.Checkpayment.Shop'}</a>.
-	</p>
-{else}
-	<p class="warning">
-		{l s='We have noticed that there is a problem with your order. If you think this is an error, you can contact our' d='Modules.Checkpayment.Shop'}
-		<a href="{$link->getPageLink('contact', true)|escape:'html'}">{l s='customer service department.' d='Modules.Checkpayment.Shop'}</a>.
-	</p>
-{/if}
+<p>{l s='For any questions or for further information, please contact our' d='Modules.Checkpayment.Shop'}
+	<a href="{$link->getPageLink('contact', true)|escape:'html'}">{l s='customer service department.' d='Modules.Checkpayment.Shop'}</a>.
+</p>


### PR DESCRIPTION
| Questions     | Answers
| ------------- | -------------------------------------------------------
| Description?  | There is no need to check for any order status, unless there was an error, this should never happen. Even if a module sneaked in some different order status, it's not a reason not to show payment information on confirmation screen. Also, every order has a reference, no need to check for it.
| Type?         | refacto
| BC breaks?    | no
| Deprecations? | no
| Fixed ticket? | Fixes https://github.com/PrestaShop/PrestaShop/issues/27688
| How to test?  | Order anything and see that everything displays correctly.

<!-- Click the form's "Preview" button to make sure the table is functional in GitHub. Thank you! -->
